### PR TITLE
Don't parse empty body

### DIFF
--- a/lib/sixpack.rb
+++ b/lib/sixpack.rb
@@ -109,7 +109,7 @@ module Sixpack
       rescue
         return {"status" => "failed", "error" => "http error"}
       end
-      if res.code == "500"
+      if res.code == "500" || res.body == ''
         {"status" => "failed", "response" => res.body}
       else
         JSON.parse(res.body)

--- a/spec/lib/sixpack_spec.rb
+++ b/spec/lib/sixpack_spec.rb
@@ -42,6 +42,14 @@ describe Sixpack do
     }.to raise_error
   end
 
+  it "should not try parse empty response body" do
+    sess = Sixpack::Session.new
+    response = double(body: '', code: 200)
+    allow_any_instance_of(Net::HTTP).to receive(:get).and_return(response)
+    res = sess.participate('show-bieber', ['trolled', 'not-trolled'])
+    expect(res["status"]).to eq('failed')
+  end
+
   it "should not allow bad alternatives names" do
     expect {
       sess = Sixpack::Session.new


### PR DESCRIPTION
In response to receiving a JSON::ParserError on one of our servers. 

Protect against an empty string as the response body from sixpack. 