### PR TITLE
Rescue from json parse error

### DIFF
--- a/lib/sixpack.rb
+++ b/lib/sixpack.rb
@@ -109,11 +109,17 @@ module Sixpack
       rescue
         return {"status" => "failed", "error" => "http error"}
       end
-      if res.code == "500" || res.body == ''
+      if res.code == "500"
         {"status" => "failed", "response" => res.body}
       else
-        JSON.parse(res.body)
+        parse_response(res)
       end
+    end
+
+    def parse_response(res)
+      JSON.parse(res.body)
+    rescue JSON::ParserError
+      {"status" => "failed", "response" => res.body}
     end
   end
 end

--- a/spec/lib/sixpack_spec.rb
+++ b/spec/lib/sixpack_spec.rb
@@ -42,9 +42,9 @@ describe Sixpack do
     }.to raise_error
   end
 
-  it "should not try parse empty response body" do
+  it "should not try parse bad response body data" do
     sess = Sixpack::Session.new
-    response = double(body: '', code: 200)
+    response = double(body: 'something unexpected', code: 200)
     allow_any_instance_of(Net::HTTP).to receive(:get).and_return(response)
     res = sess.participate('show-bieber', ['trolled', 'not-trolled'])
     expect(res["status"]).to eq('failed')


### PR DESCRIPTION
This will deal with the case where the response was unexpected or empty. 